### PR TITLE
fixing repo link, build command

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,7 +38,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/asheswook/lnurl' }
+      { icon: 'github', link: 'https://github.com/asheswook/lightning-multitool' }
     ]
   },
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -28,14 +28,14 @@ If you prefer to build the project from source, you'll need to have Go installed
 1.  **Clone the repository**
 
     ```bash
-    git clone https://github.com/asheswook/lnurl.git
-    cd lnurl
+    git clone https://github.com/asheswook/lightning-multitool
+    cd lightning-multitool
     ```
 
 2.  **Build the project**
 
     ```bash
-    go build ./cmd/server/main.go -o lightning-multitool
+    go build -o lighting-multitool ./cmd/server/main.go
     ```
 
 3.  **Run the binary**

--- a/docs/ko/guide/installation.md
+++ b/docs/ko/guide/installation.md
@@ -32,14 +32,14 @@ Lightning Multitool을 설치하는 방법에는 두 가지가 있습니다.
 1.  **리포지토리 복제**
 
     ```bash
-    git clone https://github.com/asheswook/lnurl.git
-    cd lnurl
+    git clone https://github.com/asheswook/lightning-multitool.git
+    cd lightning-multitool
     ```
 
 2.  **프로젝트 빌드**
 
     ```bash
-    go build ./cmd/server/main.go -o lightning-multitool
+    go build -o lighting-multitool ./cmd/server/main.go
     ```
 
 3.  **바이너리 실행**


### PR DESCRIPTION
- docs/.vitepress/config.mts: Fixing Old Github social link in Vitepress config
- docs/guide/installation.md: 
- docs/ko/guide/installation.md:
- The command sequence has been corrected, and git clone git url
